### PR TITLE
Fixing opening relative org board links

### DIFF
--- a/org-board.el
+++ b/org-board.el
@@ -804,9 +804,11 @@ most recent archive, in Dired."
                      (org-entry-get-multivalued-property
                       (point) "ARCHIVED_AT"))))
          (folder
-          (progn
-            (string-match "^\\[\\[file:\\(.*\\)\\]\\[.*\\]\\]$" link)
-            (match-string-no-properties 1 link)))
+          (expand-file-name
+          	(progn
+            		(string-match "^\\[\\[file:\\(.*\\)\\]\\[.*\\]\\]$" link)
+            		(match-string-no-properties 1 link))
+	 		        (file-name-directory (or buffer-file-name ""))))
          (urls
           (org-entry-get-multivalued-property (point) "URL")))
     (dolist (url-string urls)


### PR DESCRIPTION
A change to the way org-board-open was needed to handle the possibility of relative links. It will now open them based on the current buffer directory instead of the default-directory variable, which didn't always align previously.