### PR TITLE
Some minor fixes

### DIFF
--- a/org-board.el
+++ b/org-board.el
@@ -691,33 +691,39 @@ added as a link in the `ARCHIVED_AT' property."
 
   (interactive)
   (org-board-expand-regexp-alist)
-  (let* ((attach-directory (org-attach-dir t))
-         (urls (org-entry-get-multivalued-property (point) "URL"))
-         (options
-          (org-board-options-handler
-           (org-entry-get-multivalued-property (point) "WGET_OPTIONS")))
-         (timestamp (org-board-make-timestamp))
-         (output-directory (concat (file-name-as-directory attach-directory)
-                                   (file-name-as-directory timestamp)))
-         (org-id-token (org-id-get))
-         (link-to-output (if (not org-board-make-relative)
-			     (concat "[[file:" output-directory "]["
-				     timestamp "]]")
-			   (concat "[[file:" (file-relative-name output-directory)"][" timestamp "]]")))
-         (wget-process (org-board-wget-call org-board-wget-program
-                                            output-directory
-                                            options
-                                            urls)))
-    (process-put wget-process 'org-entry
-                 (org-display-outline-path nil t "/" t))
-    (process-put wget-process 'wget-output-directory
-                 output-directory)
-    (process-put wget-process 'org-id
-                 org-id-token)
-    (process-put wget-process 'urls
-                 (org-board-copy-list urls))
-    (org-entry-add-to-multivalued-property (point) "ARCHIVED_AT"
-                                           link-to-output)))
+  (save-mark-and-excursion
+    (save-window-excursion
+      (let* ((attach-directory (org-attach-dir t))
+             (urls (org-entry-get-multivalued-property (point) "URL"))
+             (options
+              (org-board-options-handler
+               (org-entry-get-multivalued-property (point) "WGET_OPTIONS")))
+             (timestamp (org-board-make-timestamp))
+             (output-directory (concat (file-name-as-directory attach-directory)
+                                       (file-name-as-directory timestamp)))
+             (org-id-token (org-id-get))
+             (link-to-output (if (not org-board-make-relative)
+			         (concat "[[file:" output-directory "]["
+				         timestamp "]]")
+			       (concat "[[file:" (file-relative-name output-directory)"][" timestamp "]]")))
+             (wget-process (org-board-wget-call org-board-wget-program
+                                                output-directory
+                                                options
+                                                urls)))
+
+        (org-id-goto org-id-token)
+        (process-put wget-process 'org-entry
+                     (org-display-outline-path nil t "/" t))
+        (process-put wget-process 'wget-output-directory
+                     output-directory)
+        (process-put wget-process 'org-id
+                     org-id-token)
+        (process-put wget-process 'urls
+                     (org-board-copy-list urls))
+
+        (org-id-goto org-id-token)
+        (org-entry-add-to-multivalued-property (point) "ARCHIVED_AT"
+                                               link-to-output)))))
 
 ;;;###autoload
 (defun org-board-archive-dry-run ()

--- a/org-board.el
+++ b/org-board.el
@@ -879,6 +879,19 @@ non-nil."
              (error (progn
                       (message "org-board-default-browser function failed: %s" err)
                       nil)))) 0)
+     ;; If org-board-default-browser is a list of functions (i.e. (list #'eww)),
+     ;; try them in order to see if any work, otherwise signal a failure.
+     ((listp org-board-default-browser)
+      (do ((idx 0 (1+ idx)))
+          ((>= idx (length org-board-default-browser)))
+        (let ((b (nth idx org-board-default-browser)))
+          (condition-case err
+              (progn
+                (funcall b filename-string)
+                (cl-return 0))
+            (error (progn
+                     (message "%s failed: %s" b err)
+                     1))))))
       ;; Otherwise, use `open' on a Mac, `xdg-open' on GNU/Linux and
       ;; BSD, and prompt for a shell command otherwise.  (What would
       ;; be the best for Windows?)  Return the exit code of the

--- a/org-board.el
+++ b/org-board.el
@@ -702,6 +702,7 @@ added as a link in the `ARCHIVED_AT' property."
              (output-directory (concat (file-name-as-directory attach-directory)
                                        (file-name-as-directory timestamp)))
              (org-id-token (org-id-get))
+             (org-entry (org-display-outline-path nil t "/" t))
              (link-to-output (if (not org-board-make-relative)
 			         (concat "[[file:" output-directory "]["
 				         timestamp "]]")
@@ -711,9 +712,8 @@ added as a link in the `ARCHIVED_AT' property."
                                                 options
                                                 urls)))
 
-        (org-id-goto org-id-token)
         (process-put wget-process 'org-entry
-                     (org-display-outline-path nil t "/" t))
+                     org-entry)
         (process-put wget-process 'wget-output-directory
                      output-directory)
         (process-put wget-process 'org-id


### PR DESCRIPTION
Fix #27 by ensuring the point is placed at the relevant bookmark entry when org-mode functions are called, using save-window-excursion and save-mark-and-excursion to keep this from affecting user experience.

Major note: As with the original code, the buffer needs to be saved manually.

Minor note: Sometimes the wget process doesn't finish by the time org-mode notices the ARCHIVED_AT link, so it initially appears dead. Waiting until the process finishes and [saving and] refreshing the buffer fixes this.

Minor note: This doesn't suppress the wget buffer, it just keeps it from appearing on-screen.